### PR TITLE
Automatic token refreshing after 60 minutes

### DIFF
--- a/src/services/authorizer.ts
+++ b/src/services/authorizer.ts
@@ -1,4 +1,6 @@
 import { parse as parseQuery } from 'querystring';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import { launch } from 'puppeteer-core';
 
 import { ChromiumResolver } from './chromium/resolver';
@@ -12,6 +14,8 @@ export class Authorizer {
     const browser = await launch({
       executablePath: await this.chromiumResolver.resolve(),
       headless: false,
+      defaultViewport: null,
+      userDataDir: join(tmpdir(), '.devoirs', 'data'),
       args: [
         '--no-sandbox',
         '--window-size=800,600',

--- a/src/services/chromium/resolver.ts
+++ b/src/services/chromium/resolver.ts
@@ -48,7 +48,7 @@ export class ChromiumResolver {
   // noinspection JSMethodCanBeStatic
   private async createDirectory(path: string): Promise<void> {
     try {
-      await mkdir(path);
+      await mkdir(path, { recursive: true });
     } catch (error) {
       if (error?.code !== 'EEXIST') {
         throw error;

--- a/src/services/chromium/resolver.ts
+++ b/src/services/chromium/resolver.ts
@@ -29,7 +29,7 @@ export class ChromiumResolver {
   async resolve(): Promise<string> {
     const context = this.context;
     const chromiumDirectory = context.directory;
-    const temporaryDirectory = join(tmpdir(), '.devoirs-chromium');
+    const temporaryDirectory = join(tmpdir(), '.devoirs', 'chromium');
 
     await this.createDirectory(temporaryDirectory);
     await this.copyDirectory(chromiumDirectory, temporaryDirectory);


### PR DESCRIPTION
Microsoft Teams requires the re-authentication after 60 minutes from issued, so the user have to put the credentials into the form.
It is f**king incovinient, so this PR solves the problem by storing browser data and refreshing token automatically.
