### PR TITLE
Avoid chmod on Win32

### DIFF
--- a/src/services/chromium/resolver.ts
+++ b/src/services/chromium/resolver.ts
@@ -7,7 +7,7 @@ import {
   promises,
   constants,
 } from 'fs';
-import { tmpdir } from 'os';
+import { tmpdir, platform } from 'os';
 import { join } from 'path';
 
 import { ChromiumContext } from './context';
@@ -36,11 +36,13 @@ export class ChromiumResolver {
 
     const executable = join(temporaryDirectory, context.executable);
 
-    // Change mode to `rwx r-x r-x`
-    await chmod(
-      executable,
-      S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH // 755
-    );
+    if (platform() !== 'win32') {
+      // Change mode to `rwx r-x r-x`
+      await chmod(
+        executable,
+        S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH // 755
+      );
+    }
 
     return executable;
   }


### PR DESCRIPTION
On Windows, Chromium resolver causes the following error excluding the first launch:

```
Error: EPERM: operation not permitted, open 'C:\Users\Siketyan\AppData\Local\Temp\.devoirs\chromium\chrome.exe'
```

The reason of the problem is the permission system is different between Unix and Windows.
So this PR solves it by avoiding mode changing only on Win32 platform.
