### PR TITLE
Prevent expand icons to be placed over header

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -17,6 +17,7 @@ header {
     padding: 15px 40px 15px 20px;
     position: fixed;
     width: 100%;
+    z-index: 2;
 }
 
 header > img {


### PR DESCRIPTION
Closes #36 

Before
![image](https://user-images.githubusercontent.com/12772118/87851982-ed037600-c938-11ea-9f19-3f527ad343c2.png)

After
![image](https://user-images.githubusercontent.com/12772118/87851985-f1c82a00-c938-11ea-9ef5-726590b49406.png)
